### PR TITLE
Upload file to client without saving to disk or keeping all chunks in memory

### DIFF
--- a/CloudMine/src/CloudMineServer/API-server/Controllers/ReturnFileController.cs
+++ b/CloudMine/src/CloudMineServer/API-server/Controllers/ReturnFileController.cs
@@ -62,20 +62,35 @@ namespace CloudMineServer.API_server.Controllers
             if (fileItem == null)
                 return BadRequest("File does not exist");
 
-            var dataChunks = fileItem.DataChunks.ToList();
-            dataChunks.Sort(new DataChunkPartNameComparer());
+            var dataChunk = await _context.GetFirstDataChunk(id);
 
             return new FileCallbackResult(new MediaTypeHeaderValue("application/octet-stream"), async (outputStream, _) =>
             {
-                foreach (var dataChunk in dataChunks)
+                while(dataChunk != null)
                 {
                     using (Stream readStream = new MemoryStream(dataChunk.Data))
                     {
                         await readStream.CopyToAsync(outputStream);
                     }
+                    dataChunk = await _context.GetNextDataChunk(dataChunk);
                 }
             })
             { FileDownloadName = fileItem.FileName };
+
+            //var dataChunks = fileItem.DataChunks.ToList();
+            //dataChunks.Sort(new DataChunkPartNameComparer());
+
+            //return new FileCallbackResult(new MediaTypeHeaderValue("application/octet-stream"), async (outputStream, _) =>
+            //{
+            //    foreach (var dataChunk in dataChunks)
+            //    {
+            //        using (Stream readStream = new MemoryStream(dataChunk.Data))
+            //        {
+            //            await readStream.CopyToAsync(outputStream);
+            //        }
+            //    }
+            //})
+            //{ FileDownloadName = fileItem.FileName };
 
 
             //var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };

--- a/CloudMine/src/CloudMineServer/API-server/Interface/ICloudMineDbService.cs
+++ b/CloudMine/src/CloudMineServer/API-server/Interface/ICloudMineDbService.cs
@@ -23,6 +23,8 @@ namespace CloudMineServer.Interface
         Task<List<FileItem>> GetAllFilItemAndDataChunks(string userId);
         Task<FileItem> GetSpecifikFileItemAndDataChunk(int id, string userId);
         Task<DataChunk> GetSpecifikDataChunk(int FileItemId, int datachunkIndex);
+        Task<DataChunk> GetFirstDataChunk(int fileItemId);
+        Task<DataChunk> GetNextDataChunk(DataChunk dataChunk);
         #endregion
 
     }

--- a/CloudMine/src/CloudMineServer/API-server/Services/CloudMineDbService.cs
+++ b/CloudMine/src/CloudMineServer/API-server/Services/CloudMineDbService.cs
@@ -1,4 +1,5 @@
-﻿using CloudMineServer.Data;
+﻿using CloudMineServer.API_server.Services;
+using CloudMineServer.Data;
 using CloudMineServer.Interface;
 using CloudMineServer.Models;
 using Microsoft.AspNetCore.Identity;
@@ -175,6 +176,22 @@ namespace CloudMineServer.Classes
             //Hypotetiskt i nuvarande metod skulle (y => y.Id == datachunkIndex) bytas till nåt i stil med (y => y.datachunkIndex == datachunkIndex)
             var dc = await _context.DataChunks.Where(x => x.FileItemId == FileItemId).FirstOrDefaultAsync(y => y.Id == datachunkIndex);
             return dc;
+        }
+
+        public async Task<DataChunk> GetFirstDataChunk(int fileItemId)
+        {
+            var anyDataChunk = await _context.DataChunks.FirstOrDefaultAsync(d => d.FileItemId == fileItemId);
+            var firstName = anyDataChunk.FirstInSequenceName();
+            var firstDataChunk = await _context.DataChunks.FirstOrDefaultAsync(d => d.PartName == firstName);
+            return firstDataChunk;
+        }
+        public async Task<DataChunk> GetNextDataChunk(DataChunk dataChunk)
+        {
+            var nextName = dataChunk.NextName();
+            if (nextName == null)
+                return null;
+            var nextDataChunk = await _context.DataChunks.FirstOrDefaultAsync(d => d.PartName == nextName);
+            return nextDataChunk;
         }
         #endregion
 

--- a/CloudMine/src/CloudMineServer/API-server/Services/DataChunkExtensions.cs
+++ b/CloudMine/src/CloudMineServer/API-server/Services/DataChunkExtensions.cs
@@ -1,0 +1,69 @@
+﻿using CloudMineServer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CloudMineServer.API_server.Services
+{
+    public static class DataChunkExtensions
+    {
+        private static readonly string _partToken = ".part_";
+        public static string NextName(this DataChunk dataChunk)
+        {
+            int partNumber = GetPartNumber(dataChunk.PartName);
+            if ((partNumber+1) > GetTotalCount(dataChunk.PartName))
+                return null;
+            return ReplacePartNumberWith(dataChunk.PartName, partNumber + 1);
+        }
+        public static string PreviousName(this DataChunk dataChunk)
+        {
+            return String.Empty;
+        }
+        public static string FirstInSequenceName(this DataChunk dataChunk)
+        {
+            return String.Empty;
+        }
+        public static string LastInSequenceName(this DataChunk dataChunk)
+        {
+            return String.Empty;
+        }
+        public static int Index(this DataChunk dataChunk)
+        {
+            return 0;
+        }
+        public static int NumberOfChunksInSequence(this DataChunk dataChunk)
+        {
+            return 0;
+        }
+        public static bool IsLastInSequence(this DataChunk dataChunk)
+        {
+            return false;
+        }
+
+        private static int GetPartNumber(string partName)
+        {
+            var partPart = partName.Split(new string[] { _partToken }, StringSplitOptions.None)[1];
+            int part = 0;
+            int.TryParse(partPart.Split('.')[0], out part);
+            return part;
+        }
+        private static int GetTotalCount(string partName)
+        {
+            var partPart = partName.Split(new string[] { _partToken }, StringSplitOptions.None)[1];
+            int count = 0;
+            int.TryParse(partPart.Split('.')[1], out count);
+            return count;
+        }
+        private static string ReplacePartNumberWith(string partName, int newPartNumber)
+        {
+            var firstPart = partName.Split(new string[] { _partToken }, StringSplitOptions.None)[0];
+            var lastPart = partName.Split(new string[] { _partToken }, StringSplitOptions.None)[1];
+            var newlastPart = 
+                lastPart.Replace(
+                    $"{GetPartNumber(partName)}.{GetTotalCount(partName)}",
+                    $"{newPartNumber.ToString()}.{GetTotalCount(partName)}");
+            return firstPart + _partToken + newlastPart;
+        }
+    }
+}

--- a/CloudMine/src/CloudMineServer/API-server/Services/DataChunkExtensions.cs
+++ b/CloudMine/src/CloudMineServer/API-server/Services/DataChunkExtensions.cs
@@ -18,28 +18,24 @@ namespace CloudMineServer.API_server.Services
         }
         public static string PreviousName(this DataChunk dataChunk)
         {
-            return String.Empty;
+            int partNumber = GetPartNumber(dataChunk.PartName);
+            if (partNumber <= 1)
+                return null;
+            return ReplacePartNumberWith(dataChunk.PartName, partNumber - 1);
         }
-        public static string FirstInSequenceName(this DataChunk dataChunk)
-        {
-            return String.Empty;
-        }
-        public static string LastInSequenceName(this DataChunk dataChunk)
-        {
-            return String.Empty;
-        }
-        public static int Index(this DataChunk dataChunk)
-        {
-            return 0;
-        }
-        public static int NumberOfChunksInSequence(this DataChunk dataChunk)
-        {
-            return 0;
-        }
-        public static bool IsLastInSequence(this DataChunk dataChunk)
-        {
-            return false;
-        }
+        public static string FirstInSequenceName(this DataChunk dataChunk) => 
+            ReplacePartNumberWith(dataChunk.PartName, 1);
+        public static string LastInSequenceName(this DataChunk dataChunk) =>
+            ReplacePartNumberWith(dataChunk.PartName, GetTotalCount(dataChunk.PartName));
+        public static int Index(this DataChunk dataChunk) =>
+            GetPartNumber(dataChunk.PartName) - 1;
+
+        public static int NumberOfChunksInSequence(this DataChunk dataChunk) =>
+            GetTotalCount(dataChunk.PartName);
+
+        public static bool IsLastInSequence(this DataChunk dataChunk) => 
+            GetTotalCount(dataChunk.PartName) == GetPartNumber(dataChunk.PartName);
+        
 
         private static int GetPartNumber(string partName)
         {

--- a/CloudMine/src/CloudMineServer/wwwroot/CookieAuth.html
+++ b/CloudMine/src/CloudMineServer/wwwroot/CookieAuth.html
@@ -30,7 +30,7 @@
     
 
     <p>
-    <a href="/api/v1.0/GetFile/NoDisk/14">Download</a>
+    <a href="/api/v1.0/GetFile/NoDisk/24">Download</a>
 
         <!--<form id="callbackForm" method="get">
             <p>Callback</p>

--- a/CloudMine/src/CloudMineServerTest/DataChunkExtenstionsTest.cs
+++ b/CloudMine/src/CloudMineServerTest/DataChunkExtenstionsTest.cs
@@ -1,0 +1,97 @@
+﻿using CloudMineServer.API_server.Services;
+using CloudMineServer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CloudMineServerTest
+{
+    public class DataChunkExtenstionsTest
+    {
+
+        [Fact]
+        public void NextNameReturnsSameNameWithPartNumberIncremented()
+        {
+            // Arrange
+            DataChunk dataChunk = new DataChunk { PartName = "test.jpg.part_8.10" };
+            // Act
+            var result = dataChunk.NextName();
+            // Assert
+            Assert.Equal("test.jpg.part_9.10", result);
+        }
+        [Fact]
+        public void NextNameReturnsNullWhenPartNumberIsLast()
+        {
+            // Arrange
+            DataChunk dataChunk = new DataChunk { PartName = "test.jpg.part_10.10" };
+            // Act
+            var result = dataChunk.NextName();
+            // Assert
+            Assert.Null(result);
+        }
+        [Fact]
+        public void PreviousNameReturnsSameNameWithPartNumberIncremented()
+        {
+            // Arrange
+            DataChunk dataChunk = new DataChunk { PartName = "test.jpg.part_8.10" };
+            // Act
+            var result = dataChunk.PreviousName();
+            // Assert
+            Assert.Equal("test.jpg.part_7.10", result);
+        }
+        [Fact]
+        public void PrevioustNameReturnsNullWhenPartNumberIsFirst()
+        {
+            // Arrange
+            DataChunk dataChunk = new DataChunk { PartName = "test.jpg.part_1.10" };
+            // Act
+            var result = dataChunk.PreviousName();
+            // Assert
+            Assert.Null(result);
+        }
+        [Fact]
+        public void FirstInSequenceNameReturnsSameNameWithPartNumberOne()
+        {
+            // Arrange
+            DataChunk dataChunk = new DataChunk { PartName = "test.jpg.part_8.10" };
+            // Act
+            var result = dataChunk.FirstInSequenceName();
+            // Assert
+            Assert.Equal("test.jpg.part_1.10", result);
+        }
+        [Fact]
+        public void LastInSequenceNameReturnsSameNameWithPartNumberLast()
+        {
+            // Arrange
+            DataChunk dataChunk = new DataChunk { PartName = "test.jpg.part_8.10" };
+            // Act
+            var result = dataChunk.LastInSequenceName();
+            // Assert
+            Assert.Equal("test.jpg.part_10.10", result);
+        }
+        [Fact]
+        public void IndexReturnsPartNumberMinusOne()
+        {
+            // Arrange
+            DataChunk dataChunk = new DataChunk { PartName = "test.jpg.part_8.10" };
+            // Act
+            var result = dataChunk.Index();
+            // Assert
+            Assert.Equal(7, result);
+        }
+        [Fact]
+        public void NumberOfChunksInSequenceReturnsLastNumberInString()
+        {
+            // Arrange
+            DataChunk dataChunk = new DataChunk { PartName = "test.jpg.part_8.10" };
+            // Act
+            var result = dataChunk.NumberOfChunksInSequence();
+            // Assert
+            Assert.Equal(10, result);
+        }
+
+    }
+
+}


### PR DESCRIPTION
GetFileNoDisk in ReturnFileController now uses GetFirstDataChunk and GetNextDataChunk. This way we will hopefully only have two datachunks in memory at once. Added extension methods to DataChunk to help with this(ie. generating name of next datachunk.)